### PR TITLE
Replace incorrect character names with correct ones

### DIFF
--- a/nous
+++ b/nous
@@ -27,14 +27,14 @@ xkb_symbols "basic" {
 
 	key <AE01>	{[	1,		exclam,		1,		1		]};
 	key <AE02>	{[	2,		at,		2,		2		]};
-	key <AE03>	{[	three,		pound,		gbp,		3		]};
-	key <AE04>	{[	four,		dollar,		cent,		4		]};
-	key <AE05>	{[	five,		percent,	permille,	5		]};
-	key <AE06>	{[	six,		asciicircum,	6,		6		]};
-	key <AE07>	{[	seven,		ampersand,	division,	7		]};
-	key <AE08>	{[	eight,		asterisk,	multiply,	8		]};
-	key <AE09>	{[	nine,		parenleft,	9,		9		]};
-	key <AE10>	{[	zero,		parenright,	0,		0		]};
+	key <AE03>	{[	3,		numbersign,	sterling,	3		]};
+	key <AE04>	{[	4,		dollar,		cent,		4		]};
+	key <AE05>	{[	5,		percent,	0x1002030,	5		]};
+	key <AE06>	{[	6,		asciicircum,	6,		6		]};
+	key <AE07>	{[	7,		ampersand,	division,	7		]};
+	key <AE08>	{[	8,		asterisk,	multiply,	8		]};
+	key <AE09>	{[	9,		parenleft,	9,		9		]};
+	key <AE10>	{[	0,		parenright,	0,		0		]};
 	key <AE11>	{[	minus,		underscore,	emdash,		1		]};
 	key <AE12>	{[	equals,		plus,		plusminus,	0x1002213	]};
 
@@ -46,7 +46,7 @@ xkb_symbols "basic" {
 	key <AD06>	{[	y,		Y,		0x1000296,	0x100035C	]};
 	key <AD07>	{[	u,		U,		0x10030C4,	0x1003064	]};
 	key <AD08>	{[	i,		I,		0x100221A,	0x100221A	]};
-	key <AD09>	{[	o,		O,		Greek_theta,	Greek_THETHA	]};
+	key <AD09>	{[	o,		O,		Greek_theta,	Greek_THETA	]};
 	key <AD10>	{[	p,		P,		Greek_pi,	Greek_PI	]};
 	key <AD11>	{[	bracketleft,	braceleft,	aring,		Aring		]};
 	key <AD12>	{[	bracketright,	braceright,	dead_diaeresis,	dead_circumflex	]};
@@ -60,9 +60,9 @@ xkb_symbols "basic" {
 	key <AC07>	{[	j,		J,		downarrow,	downarrow	]};
 	key <AC08>	{[	k,		K,		uparrow,	uparrow		]};
 	key <AC09>	{[	l,		L,		rightarrow,	rightarrow	]};
-	key <AC10>	{[	semicolon,	colon,		oslash,		Ooblique	]};
+	key <AC10>	{[	semicolon,	colon,		oslash,		Oslash		]};
 	key <AC11>	{[	apostrophe,	quotedbl,	ae,		AE		]};
-	key <BKSL>	{[	backslash,	pipe,		dead_acute,	dead_grave	]};
+	key <BKSL>	{[	backslash,	bar,		dead_acute,	dead_grave	]};
 
 	key <AB01>	{[	z,		Z,		0x1002124,	0x1002211	]};
 	key <AB02>	{[	x,		X,		x,		X		]};


### PR DESCRIPTION
I couldn't figure out what character `no` (shift+altgr+n) was supposed to be so I didn't change it.